### PR TITLE
Return data for all feeds on a given IP address

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    transform: {'^.+\\.ts?$': 'ts-jest'},
+    testEnvironment: 'node',
+    testRegex: '/test/.*\\.(test|spec)?\\.(ts|tsx)$',
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node']
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "ts-node src/Main.ts"
+    "start": "ts-node src/Main.ts",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -20,7 +21,10 @@
     "@tsconfig/node18-strictest": "^1.0.0",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.16",
+    "@types/jest": "^29.5.5",
     "@types/node": "^18.11.18",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
   },

--- a/src/IpStats.ts
+++ b/src/IpStats.ts
@@ -1,0 +1,145 @@
+export class BeastEntry {
+    uuid: string;
+    ip: string;
+    port: number;
+    bandwidthKbps: number;
+    unknownThing: number;
+    messagesPerSecond: number;
+    positionsPerSecond: number;
+    latencyMs: number;
+    positionsTotal: number;
+
+    constructor(uuid: string, ip: string, port: number, bandwidthKbps: number, unknownThing: number, messagesPerSecond: number, positionsPerSecond: number, latencyMs: number, positionsTotal: number) {
+        this.uuid = uuid;
+        this.ip = ip;
+        this.port = port;
+        this.bandwidthKbps = bandwidthKbps;
+        this.unknownThing = unknownThing;
+        this.messagesPerSecond = messagesPerSecond;
+        this.positionsPerSecond = positionsPerSecond;
+        this.latencyMs = latencyMs;
+        this.positionsTotal = positionsTotal;
+    }
+
+    static fromArray(arr: any[]): BeastEntry {
+        const uuid = arr[0];
+        const ip = arr[1].split("port")[0].trim() || null;
+        const port = parseInt(arr[1].trim().split('port')[1].trim());
+        const bandwidthKbps = arr[2];
+        const unknownThing = arr[3];
+        const messagesPerSecond = arr[4];
+        const positionsPerSecond = arr[5];
+        const latencyMs = arr[6];
+        const positionsTotal = arr[7];
+
+        return new BeastEntry(
+            uuid,
+            ip,
+            port,
+            bandwidthKbps,
+            unknownThing,
+            messagesPerSecond,
+            positionsPerSecond,
+            latencyMs,
+            positionsTotal
+        );
+    }
+}
+
+export class MlatEntry {
+    user: string;
+    uid: number;
+    uuid: string;
+    coords: string;
+    lat: number;
+    lon: number;
+    alt: number;
+    privacy: boolean;
+    connection: string;
+    source_ip: string;
+    source_port: string;
+    message_rate: number;
+    peer_count: number;
+    bad_sync_timeout: number;
+    outlier_percent: number;
+    bad_peer_list: string;
+    sync_interest: string[];
+    mlat_interest: string[];
+
+    constructor(user: string, uid: number, uuid: string, coords: string, lat: number, lon: number, alt: number, privacy: boolean, connection: string, source_ip: string, source_port: string, message_rate: number, peer_count: number, bad_sync_timeout: number, outlier_percent: number, bad_peer_list: string, sync_interest: string[], mlat_interest: string[]) {
+        this.user = user;
+        this.uid = uid;
+        this.uuid = uuid;
+        this.coords = coords;
+        this.lat = lat;
+        this.lon = lon;
+        this.alt = alt;
+        this.privacy = privacy;
+        this.connection = connection;
+        this.source_ip = source_ip;
+        this.source_port = source_port;
+        this.message_rate = message_rate;
+        this.peer_count = peer_count;
+        this.bad_sync_timeout = bad_sync_timeout;
+        this.outlier_percent = outlier_percent;
+        this.bad_peer_list = bad_peer_list;
+        this.sync_interest = sync_interest;
+        this.mlat_interest = mlat_interest;
+    }
+
+    static fromObject(obj: any): MlatEntry {
+        return new MlatEntry(
+            obj.user,
+            obj.uid,
+            obj.uuid,
+            obj.coords,
+            obj.lat,
+            obj.lon,
+            obj.alt,
+            obj.privacy,
+            obj.connection,
+            obj.source_ip,
+            obj.source_port,
+            obj.message_rate,
+            obj.peer_count,
+            obj.bad_sync_timeout,
+            obj.outlier_percent,
+            obj.bad_peer_list,
+            obj.sync_interest,
+            obj.mlat_interest
+        );
+    }
+
+}
+
+
+export function getIpData(ipAddress: string, beastJsonFileContent: string, mlatFileContentFileContent: string) {
+
+    const myIpResults: { mlatData: MlatEntry[]; beastData: BeastEntry[]; uuids: any[] } = {
+        uuids: [],
+        beastData: [],
+        mlatData: [],
+    };
+
+    const beastJson = JSON.parse(beastJsonFileContent);
+    const beastClients: BeastEntry[] = beastJson[`clients`].map(BeastEntry.fromArray);
+    const matchingBeastEntries = beastClients.filter((entry: BeastEntry) => entry.ip === ipAddress);
+
+    const matchingBeastUuids = matchingBeastEntries.map((entry: BeastEntry) => entry.uuid);
+
+    const mlatJson = JSON.parse(mlatFileContentFileContent);
+    const mlatClientEntries: MlatEntry[] = Object.values(mlatJson).map(MlatEntry.fromObject);
+    const matchingMlatEntries = mlatClientEntries.filter((entry: MlatEntry) => entry.source_ip === ipAddress);
+
+    const matchingMlatUuids = matchingMlatEntries.map((entry: MlatEntry) => entry.uuid);
+
+    const matchingUuids: Set<string> = new Set();
+    matchingBeastUuids.forEach((uuid: string) => matchingUuids.add(uuid));
+    matchingMlatUuids.forEach((uuid: string) => matchingUuids.add(uuid));
+
+    myIpResults.beastData = matchingBeastEntries;
+    myIpResults.mlatData = matchingMlatEntries;
+    myIpResults.uuids = [...matchingUuids];
+
+    return myIpResults;
+}

--- a/src/IpStats.ts
+++ b/src/IpStats.ts
@@ -115,7 +115,8 @@ export class MlatEntry {
 
 export function getIpData(ipAddress: string, beastJsonFileContent: string, mlatFileContentFileContent: string) {
 
-    const myIpResults: { mlatData: MlatEntry[]; beastData: BeastEntry[]; uuids: any[] } = {
+    const myIpResults: { ip: string, mlatData: MlatEntry[]; beastData: BeastEntry[]; uuids: any[] } = {
+        ip: ipAddress,
         uuids: [],
         beastData: [],
         mlatData: [],

--- a/src/IpStats.ts
+++ b/src/IpStats.ts
@@ -29,8 +29,8 @@ export class BeastEntry {
         const connectionTimeSeconds = arr[3];
         const messagesPerSecond = arr[4];
         const positionsPerSecond = arr[5];
-        const latencyMs = arr[6];
-        const positionsTotal = arr[7];
+        const latencyMs = arr[7];
+        const positionsTotal = arr[8];
 
         return new BeastEntry(
             uuid,

--- a/src/IpStats.ts
+++ b/src/IpStats.ts
@@ -3,18 +3,18 @@ export class BeastEntry {
     ip: string;
     port: number;
     bandwidthKbps: number;
-    unknownThing: number;
+    connectionTimeSeconds: number;
     messagesPerSecond: number;
     positionsPerSecond: number;
     latencyMs: number;
     positionsTotal: number;
 
-    constructor(uuid: string, ip: string, port: number, bandwidthKbps: number, unknownThing: number, messagesPerSecond: number, positionsPerSecond: number, latencyMs: number, positionsTotal: number) {
+    constructor(uuid: string, ip: string, port: number, bandwidthKbps: number, connectionTimeSeconds: number, messagesPerSecond: number, positionsPerSecond: number, latencyMs: number, positionsTotal: number) {
         this.uuid = uuid;
         this.ip = ip;
         this.port = port;
         this.bandwidthKbps = bandwidthKbps;
-        this.unknownThing = unknownThing;
+        this.connectionTimeSeconds = connectionTimeSeconds;
         this.messagesPerSecond = messagesPerSecond;
         this.positionsPerSecond = positionsPerSecond;
         this.latencyMs = latencyMs;
@@ -26,7 +26,7 @@ export class BeastEntry {
         const ip = arr[1].split("port")[0].trim() || null;
         const port = parseInt(arr[1].trim().split('port')[1].trim());
         const bandwidthKbps = arr[2];
-        const unknownThing = arr[3];
+        const connectionTimeSeconds = arr[3];
         const messagesPerSecond = arr[4];
         const positionsPerSecond = arr[5];
         const latencyMs = arr[6];
@@ -37,7 +37,7 @@ export class BeastEntry {
             ip,
             port,
             bandwidthKbps,
-            unknownThing,
+            connectionTimeSeconds,
             messagesPerSecond,
             positionsPerSecond,
             latencyMs,

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -149,7 +149,155 @@ server.get('/v3/myip/', async (req: any, res) => {
     res.send(myipRes);
 });
 
-// Returns current number of beast and mlat feeders
+
+class BeastEntry {
+    uuid: string;
+    ip: string;
+    port: number;
+    bandwidthKbps: number;
+    unknownThing: number;
+    messagesPerSecond: number;
+    positionsPerSecond: number;
+    latencyMs: number;
+    positionsTotal: number;
+
+    constructor(uuid: string, ip: string, port: number, bandwidthKbps: number, unknownThing: number, messagesPerSecond: number, positionsPerSecond: number, latencyMs: number, positionsTotal: number) {
+        this.uuid = uuid;
+        this.ip = ip;
+        this.port = port;
+        this.bandwidthKbps = bandwidthKbps;
+        this.unknownThing = unknownThing;
+        this.messagesPerSecond = messagesPerSecond;
+        this.positionsPerSecond = positionsPerSecond;
+        this.latencyMs = latencyMs;
+        this.positionsTotal = positionsTotal;
+    }
+
+    static fromArray(arr: any[]): BeastEntry {
+        const uuid = arr[0];
+        const ip = arr[1].split("port")[0].trim() || null;
+        const port = parseInt(arr[1].trim().split('port')[1].trim());
+        const bandwidthKbps = arr[2];
+        const unknownThing = arr[3];
+        const messagesPerSecond = arr[4];
+        const positionsPerSecond = arr[5];
+        const latencyMs = arr[6];
+        const positionsTotal = arr[7];
+
+        return new BeastEntry(
+            uuid,
+            ip,
+            port,
+            bandwidthKbps,
+            unknownThing,
+            messagesPerSecond,
+            positionsPerSecond,
+            latencyMs,
+            positionsTotal
+        );
+    }
+}
+
+class MlatEntry {
+    user: string;
+    uid: number;
+    uuid: string;
+    coords: string;
+    lat: number;
+    lon: number;
+    alt: number;
+    privacy: boolean;
+    connection: string;
+    source_ip: string;
+    source_port: string;
+    message_rate: number;
+    peer_count: number;
+    bad_sync_timeout: number;
+    outlier_percent: number;
+    bad_peer_list: string;
+    sync_interest: string[];
+    mlat_interest: string[];
+
+    constructor(user: string, uid: number, uuid: string, coords: string, lat: number, lon: number, alt: number, privacy: boolean, connection: string, source_ip: string, source_port: string, message_rate: number, peer_count: number, bad_sync_timeout: number, outlier_percent: number, bad_peer_list: string, sync_interest: string[], mlat_interest: string[]) {
+        this.user = user;
+        this.uid = uid;
+        this.uuid = uuid;
+        this.coords = coords;
+        this.lat = lat;
+        this.lon = lon;
+        this.alt = alt;
+        this.privacy = privacy;
+        this.connection = connection;
+        this.source_ip = source_ip;
+        this.source_port = source_port;
+        this.message_rate = message_rate;
+        this.peer_count = peer_count;
+        this.bad_sync_timeout = bad_sync_timeout;
+        this.outlier_percent = outlier_percent;
+        this.bad_peer_list = bad_peer_list;
+        this.sync_interest = sync_interest;
+        this.mlat_interest = mlat_interest;
+    }
+
+    static fromObject(obj: any): MlatEntry {
+        return new MlatEntry(
+            obj.user,
+            obj.uid,
+            obj.uuid,
+            obj.coords,
+            obj.lat,
+            obj.lon,
+            obj.alt,
+            obj.privacy,
+            obj.connection,
+            obj.source_ip,
+            obj.source_port,
+            obj.message_rate,
+            obj.peer_count,
+            obj.bad_sync_timeout,
+            obj.outlier_percent,
+            obj.bad_peer_list,
+            obj.sync_interest,
+            obj.mlat_interest
+        );
+    }
+
+}
+// Get details of connecting IP's stats
+server.get('/v4/myip/', async (req: any, res) => {
+    const ipAddress = requestIP.getClientIp(req);
+
+    const myIpResults: { mlatData: MlatEntry[]; beastData: BeastEntry[]; uuids: any[] } = {
+        uuids: [],
+        beastData: [],
+        mlatData: [],
+    };
+
+    const beastJson = JSON.parse(fs.readFileSync('/run/readsb/clients.json'));
+    const beastClients: BeastEntry[] = beastJson[`clients`].map(BeastEntry.fromArray);
+    const matchingBeastEntries = beastClients.filter((entry:BeastEntry) => entry.ip === ipAddress);
+
+    const matchingBeastUuids = matchingBeastEntries.map((entry:BeastEntry) =>  entry.uuid );
+
+    const mlatJson = JSON.parse(fs.readFileSync('/run/mlat-server/clients.json'));
+    const mlatClientEntries: MlatEntry[] = Object.values(mlatJson).map(MlatEntry.fromObject);
+    const matchingMlatEntries = mlatClientEntries.filter((entry:MlatEntry) => entry.source_ip === ipAddress);
+
+    const matchingMlatUuids = matchingMlatEntries.map((entry:MlatEntry) =>  entry.uuid );
+
+    const matchingUuids : Set<string> = new Set();
+    matchingBeastUuids.forEach((uuid:string) => matchingUuids.add(uuid));
+    matchingMlatUuids.forEach((uuid:string) => matchingUuids.add(uuid));
+
+    myIpResults.beastData = matchingBeastEntries;
+    myIpResults.mlatData = matchingMlatEntries;
+    myIpResults.uuids = [...matchingUuids];
+
+    res.type('json');
+    res.send(myIpResults);
+});
+
+// Returns current number of Beast and MLAT feeders
 server.get('/v3/feedcount/', async (_req: any, res) => {
     var beastJSON = JSON.parse(fs.readFileSync('/run/readsb/clients.json'));
     var mlatJSON = JSON.parse(fs.readFileSync('/run/mlat-server/clients.json'));

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -4,6 +4,8 @@ import * as Express from 'express';
 const requestIP = require('request-ip');
 const fs = require('fs');
 
+import {getIpData} from "./IpStats";
+
 const server = Express.default();
 
 server.use(CORS.default());
@@ -150,152 +152,19 @@ server.get('/v3/myip/', async (req: any, res) => {
 });
 
 
-class BeastEntry {
-    uuid: string;
-    ip: string;
-    port: number;
-    bandwidthKbps: number;
-    unknownThing: number;
-    messagesPerSecond: number;
-    positionsPerSecond: number;
-    latencyMs: number;
-    positionsTotal: number;
-
-    constructor(uuid: string, ip: string, port: number, bandwidthKbps: number, unknownThing: number, messagesPerSecond: number, positionsPerSecond: number, latencyMs: number, positionsTotal: number) {
-        this.uuid = uuid;
-        this.ip = ip;
-        this.port = port;
-        this.bandwidthKbps = bandwidthKbps;
-        this.unknownThing = unknownThing;
-        this.messagesPerSecond = messagesPerSecond;
-        this.positionsPerSecond = positionsPerSecond;
-        this.latencyMs = latencyMs;
-        this.positionsTotal = positionsTotal;
-    }
-
-    static fromArray(arr: any[]): BeastEntry {
-        const uuid = arr[0];
-        const ip = arr[1].split("port")[0].trim() || null;
-        const port = parseInt(arr[1].trim().split('port')[1].trim());
-        const bandwidthKbps = arr[2];
-        const unknownThing = arr[3];
-        const messagesPerSecond = arr[4];
-        const positionsPerSecond = arr[5];
-        const latencyMs = arr[6];
-        const positionsTotal = arr[7];
-
-        return new BeastEntry(
-            uuid,
-            ip,
-            port,
-            bandwidthKbps,
-            unknownThing,
-            messagesPerSecond,
-            positionsPerSecond,
-            latencyMs,
-            positionsTotal
-        );
-    }
-}
-
-class MlatEntry {
-    user: string;
-    uid: number;
-    uuid: string;
-    coords: string;
-    lat: number;
-    lon: number;
-    alt: number;
-    privacy: boolean;
-    connection: string;
-    source_ip: string;
-    source_port: string;
-    message_rate: number;
-    peer_count: number;
-    bad_sync_timeout: number;
-    outlier_percent: number;
-    bad_peer_list: string;
-    sync_interest: string[];
-    mlat_interest: string[];
-
-    constructor(user: string, uid: number, uuid: string, coords: string, lat: number, lon: number, alt: number, privacy: boolean, connection: string, source_ip: string, source_port: string, message_rate: number, peer_count: number, bad_sync_timeout: number, outlier_percent: number, bad_peer_list: string, sync_interest: string[], mlat_interest: string[]) {
-        this.user = user;
-        this.uid = uid;
-        this.uuid = uuid;
-        this.coords = coords;
-        this.lat = lat;
-        this.lon = lon;
-        this.alt = alt;
-        this.privacy = privacy;
-        this.connection = connection;
-        this.source_ip = source_ip;
-        this.source_port = source_port;
-        this.message_rate = message_rate;
-        this.peer_count = peer_count;
-        this.bad_sync_timeout = bad_sync_timeout;
-        this.outlier_percent = outlier_percent;
-        this.bad_peer_list = bad_peer_list;
-        this.sync_interest = sync_interest;
-        this.mlat_interest = mlat_interest;
-    }
-
-    static fromObject(obj: any): MlatEntry {
-        return new MlatEntry(
-            obj.user,
-            obj.uid,
-            obj.uuid,
-            obj.coords,
-            obj.lat,
-            obj.lon,
-            obj.alt,
-            obj.privacy,
-            obj.connection,
-            obj.source_ip,
-            obj.source_port,
-            obj.message_rate,
-            obj.peer_count,
-            obj.bad_sync_timeout,
-            obj.outlier_percent,
-            obj.bad_peer_list,
-            obj.sync_interest,
-            obj.mlat_interest
-        );
-    }
-
-}
 // Get details of connecting IP's stats
 server.get('/v4/myip/', async (req: any, res) => {
     const ipAddress = requestIP.getClientIp(req);
 
-    const myIpResults: { mlatData: MlatEntry[]; beastData: BeastEntry[]; uuids: any[] } = {
-        uuids: [],
-        beastData: [],
-        mlatData: [],
-    };
+    const beastJsonFileContent = fs.readFileSync('/run/readsb/clients.json');
+    const mlatJsonFileContent = fs.readFileSync('/run/mlat-server/clients.json');
 
-    const beastJson = JSON.parse(fs.readFileSync('/run/readsb/clients.json'));
-    const beastClients: BeastEntry[] = beastJson[`clients`].map(BeastEntry.fromArray);
-    const matchingBeastEntries = beastClients.filter((entry:BeastEntry) => entry.ip === ipAddress);
-
-    const matchingBeastUuids = matchingBeastEntries.map((entry:BeastEntry) =>  entry.uuid );
-
-    const mlatJson = JSON.parse(fs.readFileSync('/run/mlat-server/clients.json'));
-    const mlatClientEntries: MlatEntry[] = Object.values(mlatJson).map(MlatEntry.fromObject);
-    const matchingMlatEntries = mlatClientEntries.filter((entry:MlatEntry) => entry.source_ip === ipAddress);
-
-    const matchingMlatUuids = matchingMlatEntries.map((entry:MlatEntry) =>  entry.uuid );
-
-    const matchingUuids : Set<string> = new Set();
-    matchingBeastUuids.forEach((uuid:string) => matchingUuids.add(uuid));
-    matchingMlatUuids.forEach((uuid:string) => matchingUuids.add(uuid));
-
-    myIpResults.beastData = matchingBeastEntries;
-    myIpResults.mlatData = matchingMlatEntries;
-    myIpResults.uuids = [...matchingUuids];
+    const myIpResults = getIpData(ipAddress, beastJsonFileContent, mlatJsonFileContent);
 
     res.type('json');
     res.send(myIpResults);
 });
+
 
 // Returns current number of Beast and MLAT feeders
 server.get('/v3/feedcount/', async (_req: any, res) => {

--- a/test/IpStats.test.ts
+++ b/test/IpStats.test.ts
@@ -1,0 +1,260 @@
+import {BeastEntry, getIpData, MlatEntry} from '../src/IpStats';
+import {describe} from "node:test";
+
+
+describe('testing BeastEntry', () => {
+    test('simple constructor of single entry maps values as expected', () => {
+        const sampleBeastEntry = `[
+    "6278da69-1787-4f4b-ac56-eb64ec3aa55e",
+    "                       1.2.3.4 port 46358",
+    15.36,
+    1523,
+    88.091,
+    17.626,
+    0,
+    60,
+    26844
+  ]`;
+
+        const beastEntry = BeastEntry.fromArray(JSON.parse(sampleBeastEntry));
+
+        expect(beastEntry).not.toBeNull();
+        expect(beastEntry.uuid).toBe("6278da69-1787-4f4b-ac56-eb64ec3aa55e");
+        expect(beastEntry.ip).toBe("1.2.3.4");
+        expect(beastEntry.port).toBe(46358);
+        expect(beastEntry.bandwidthKbps).toBe(15.36);
+        expect(beastEntry.unknownThing).toBe(1523);
+        expect(beastEntry.messagesPerSecond).toBe(88.091);
+        expect(beastEntry.positionsPerSecond).toBe(17.626);
+        expect(beastEntry.latencyMs).toBe(0);
+        expect(beastEntry.positionsTotal).toBe(60);
+    })
+});
+describe('testing MlatEntry', () => {
+    test('simple constructor of single entry maps values as expected', () => {
+
+        const sampleMlatEntry = `{
+    "user": "ARBITRARY_USER_DISPLAY_NAME",
+    "uid": 243,
+    "uuid": "6278da69-1787-4f4b-ac56-eb64ec3aa55e",
+    "coords": "51.558320,-0.322240",
+    "lat": 51.0,
+    "lon": -0.0,
+    "alt": 60.0,
+    "privacy": false,
+    "connection": "ARBITRARY_USER_DISPLAY_NAME v3 dump1090 0.4.2 tcp zlib2",
+    "source_ip": "1.2.3.4",
+    "source_port": "33418",
+    "message_rate": 5,
+    "peer_count": 16,
+    "bad_sync_timeout": 0,
+    "outlier_percent": 0.7,
+    "bad_peer_list": "[]",
+    "sync_interest": [
+      "406696",
+      "3c5432",
+      "4ca892",
+      "4ca935",
+      "406540",
+      "40773b"
+    ],
+    "mlat_interest": [
+      "4cace0"
+    ]
+  }`;
+
+
+        const mlatEntry = MlatEntry.fromObject((JSON.parse(sampleMlatEntry)));
+
+        expect(mlatEntry).not.toBeNull();
+        expect(mlatEntry.user).toBe("ARBITRARY_USER_DISPLAY_NAME");
+        expect(mlatEntry.uid).toBe(243);
+        expect(mlatEntry.uuid).toBe("6278da69-1787-4f4b-ac56-eb64ec3aa55e");
+        expect(mlatEntry.coords).toBe("51.558320,-0.322240");
+        expect(mlatEntry.lat).toBe(51.0);
+        expect(mlatEntry.lon).toBe(-0.0);
+        expect(mlatEntry.alt).toBe(60.0);
+        expect(mlatEntry.privacy).toBe(false);
+        expect(mlatEntry.connection).toBe("ARBITRARY_USER_DISPLAY_NAME v3 dump1090 0.4.2 tcp zlib2");
+        expect(mlatEntry.source_ip).toBe("1.2.3.4");
+        expect(mlatEntry.source_port).toBe("33418");
+        expect(mlatEntry.message_rate).toBe(5);
+        expect(mlatEntry.peer_count).toBe(16);
+        expect(mlatEntry.bad_sync_timeout).toBe(0);
+        expect(mlatEntry.outlier_percent).toBe(0.7);
+        expect(mlatEntry.bad_peer_list).toBe("[]");
+        expect(mlatEntry.sync_interest).toStrictEqual(["406696", "3c5432", "4ca892", "4ca935", "406540", "40773b"]);
+        expect(mlatEntry.mlat_interest).toStrictEqual(["4cace0"]);
+    })
+});
+
+describe('testing multiple values', () => {
+    test('multiple entries are parsed as expected', () => {
+        const sampleBeastFile = `{
+  "clients": [
+    [
+      "d4ca9fce-dfd2-afae-0000-000000000000",
+      "                                   ::1 port 37540",
+      1.26,
+      510348,
+      1.359,
+      0.731,
+      0,
+      -1,
+      372939
+    ],
+    [
+      "6278da69-1787-4f4b-ac56-eb64ec3aa55e",
+      "                       1.2.3.4 port 46358",
+      15.36,
+      1523,
+      88.091,
+      17.626,
+      0,
+      60,
+      26844
+    ],
+    [
+      "12108031-f8f1-454f-9274-5dabfea5f7b6",
+      "                       1.2.3.4 port 46358",
+      15.36,
+      1523,
+      88.091,
+      17.626,
+      0,
+      60,
+      26844
+    ],
+    [
+      "69ce7f6f-cacf-4723-93ed-af306c0752c9",
+      "                       1.2.3.4 port 46358",
+      15.36,
+      1523,
+      88.091,
+      17.626,
+      0,
+      60,
+      26844
+    ],
+    [
+      "33ee1ef3-cf8c-4a09-9d4c-b3f02065d5af",
+      "                       1.2.3.4 port 46358",
+      15.36,
+      1523,
+      88.091,
+      17.626,
+      0,
+      60,
+      26844
+    ]
+  ]
+}`;
+
+        const sampleMlatFile = `{
+  "ARBITRARY_USER_DISPLAY_NAME": {
+    "user": "ARBITRARY_USER_DISPLAY_NAME",
+    "uid": 243,
+    "uuid": "6278da69-1787-4f4b-ac56-eb64ec3aa55e",
+    "coords": "51.0,-0.0",
+    "lat": 51.0,
+    "lon": -0.0,
+    "alt": 60.0,
+    "privacy": false,
+    "connection": "ARBITRARY_USER_DISPLAY_NAME v3 dump1090 0.4.2 tcp zlib2",
+    "source_ip": "1.2.3.4",
+    "source_port": "33418",
+    "message_rate": 5,
+    "peer_count": 16,
+    "bad_sync_timeout": 0,
+    "outlier_percent": 0.7,
+    "bad_peer_list": "[]",
+    "sync_interest": [
+      "406696",
+      "3c5432",
+      "4ca892",
+      "4ca935",
+      "406540",
+      "40773b"
+    ],
+    "mlat_interest": [
+      "4cace0"
+    ]
+  },
+  "ARBITRARY_USER_DISPLAY_NAME_2": {
+    "user": "ARBITRARY_USER_DISPLAY_NAME_2",
+    "uid": 243,
+    "uuid": "faaf8e48-e691-447b-aa57-e4196d4952e2",
+    "coords": "51.0,-0.0",
+    "lat": 51.0,
+    "lon": -0.0,
+    "alt": 60.0,
+    "privacy": false,
+    "connection": "ARBITRARY_USER_DISPLAY_NAME_2 v3 dump1090 0.4.2 tcp zlib2",
+    "source_ip": "1.2.3.4",
+    "source_port": "33418",
+    "message_rate": 5,
+    "peer_count": 16,
+    "bad_sync_timeout": 0,
+    "outlier_percent": 0.7,
+    "bad_peer_list": "[]",
+    "sync_interest": [
+      "406696",
+      "3c5432",
+      "4ca892",
+      "4ca935",
+      "406540",
+      "40773b"
+    ],
+    "mlat_interest": [
+      "4cace0"
+    ]
+  },
+  "ARBITRARY_USER_DISPLAY_NAME_3": {
+    "user": "ARBITRARY_USER_DISPLAY_NAME_3",
+    "uid": 243,
+    "uuid": "6278da69-1787-4f4b-ac56-eb64ec3aa55e",
+    "coords": "51.0,-0.0",
+    "lat": 51.0,
+    "lon": -0.0,
+    "alt": 60.0,
+    "privacy": false,
+    "connection": "ARBITRARY_USER_DISPLAY_NAME_3 v3 dump1090 0.4.2 tcp zlib2",
+    "source_ip": "9.8.7.6",
+    "source_port": "33418",
+    "message_rate": 5,
+    "peer_count": 16,
+    "bad_sync_timeout": 0,
+    "outlier_percent": 0.7,
+    "bad_peer_list": "[]",
+    "sync_interest": [
+      "406696",
+      "3c5432",
+      "4ca892",
+      "4ca935",
+      "406540",
+      "40773b"
+    ],
+    "mlat_interest": [
+      "4cace0"
+    ]
+  }
+}`;
+
+        const ipAddress = '1.2.3.4';
+        const ipStats = getIpData(ipAddress, sampleBeastFile, sampleMlatFile);
+
+        expect(ipStats).not.toBeNull();
+
+        // Only 4 of the 5 beast entries match the given IP address
+        expect(ipStats.beastData.length).toBe(4);
+
+        // Only 2 of the 3 mlat entries match the given IP address
+        expect(ipStats.mlatData.length).toBe(2);
+
+        // Each of the 4 beast entries has a unique UUID
+        // Each of the 2 mlat entries has a unique UUID
+        // There is one overlap in UUID between Beast and MLAT
+        // Therefore the expected total number of unique UUIDs is 5
+        expect(ipStats.uuids.length).toBe(5);
+    })
+});

--- a/test/IpStats.test.ts
+++ b/test/IpStats.test.ts
@@ -23,7 +23,7 @@ describe('testing BeastEntry', () => {
         expect(beastEntry.ip).toBe("1.2.3.4");
         expect(beastEntry.port).toBe(46358);
         expect(beastEntry.bandwidthKbps).toBe(15.36);
-        expect(beastEntry.unknownThing).toBe(1523);
+        expect(beastEntry.connectionTimeSeconds).toBe(1523);
         expect(beastEntry.messagesPerSecond).toBe(88.091);
         expect(beastEntry.positionsPerSecond).toBe(17.626);
         expect(beastEntry.latencyMs).toBe(0);

--- a/test/IpStats.test.ts
+++ b/test/IpStats.test.ts
@@ -26,8 +26,9 @@ describe('testing BeastEntry', () => {
         expect(beastEntry.connectionTimeSeconds).toBe(1523);
         expect(beastEntry.messagesPerSecond).toBe(88.091);
         expect(beastEntry.positionsPerSecond).toBe(17.626);
-        expect(beastEntry.latencyMs).toBe(0);
-        expect(beastEntry.positionsTotal).toBe(60);
+        // expect(beastEntry.TBC).toBe(0);
+        expect(beastEntry.latencyMs).toBe(60);
+        expect(beastEntry.positionsTotal).toBe(26844);
     })
 });
 describe('testing MlatEntry', () => {

--- a/test/IpStats.test.ts
+++ b/test/IpStats.test.ts
@@ -246,16 +246,19 @@ describe('testing multiple values', () => {
 
         expect(ipStats).not.toBeNull();
 
-        // Only 4 of the 5 beast entries match the given IP address
-        expect(ipStats.beastData.length).toBe(4);
+        // The given IP address should be included in the response
+        expect(ipStats.ip).toBe(ipAddress);
 
-        // Only 2 of the 3 mlat entries match the given IP address
-        expect(ipStats.mlatData.length).toBe(2);
-
-        // Each of the 4 beast entries has a unique UUID
-        // Each of the 2 mlat entries has a unique UUID
-        // There is one overlap in UUID between Beast and MLAT
-        // Therefore the expected total number of unique UUIDs is 5
-        expect(ipStats.uuids.length).toBe(5);
+        // // Only 4 of the 5 beast entries match the given IP address
+        // expect(ipStats.beastData.length).toBe(4);
+        //
+        // // Only 2 of the 3 mlat entries match the given IP address
+        // expect(ipStats.mlatData.length).toBe(2);
+        //
+        // // Each of the 4 beast entries has a unique UUID
+        // // Each of the 2 mlat entries has a unique UUID
+        // // There is one overlap in UUID between Beast and MLAT
+        // // Therefore the expected total number of unique UUIDs is 5
+        // expect(ipStats.uuids.length).toBe(5);
     })
 });


### PR DESCRIPTION
**Changes to behaviour and the API response structure**
- Previously, with `v3` of this API endpoint, it would return the first Beast and MLAT entry found in a two-element array.
- This pull request (PR) changes the API response to be an object containing arrays of Beast/MLAT entries, in addition to an array of unique UUIDs found.
- This PR retains the v3 API (the IP stats page still requires it), and introduces an v4 alongside it

**Introduction of types**
- Previously the API (and the JavaScript consumer of the API) work with low-level detail, accessing specific indices of arrays and other "magic number" type behaviour where 
- TypeScript allows for types to be defined, where each value/property/field is explicitly named
- This PR introduces TS classes to represent the data entries

**Introduction of tests**
- To verify the behaviour, I've added Jest as a dependency and written unit tests
- While there are many many more tests which theoretically could be written, these three cover most bases and works well as a starting point